### PR TITLE
Refactor to be promise based

### DIFF
--- a/android/src/main/java/com/github/wumke/RNImmediatePhoneCall/RNImmediatePhoneCallModule.java
+++ b/android/src/main/java/com/github/wumke/RNImmediatePhoneCall/RNImmediatePhoneCallModule.java
@@ -16,11 +16,7 @@ import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.modules.core.PermissionListener;
 
-public class RNImmediatePhoneCallModule extends ReactContextBaseJavaModule implements PermissionListener {
-
-    private Promise promise;
-    private String number = "";
-    private static final int PERMISSIONS_REQUEST_ACCESS_CALL = 101;
+public class RNImmediatePhoneCallModule extends ReactContextBaseJavaModule {
 
     public RNImmediatePhoneCallModule(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -46,45 +42,13 @@ public class RNImmediatePhoneCallModule extends ReactContextBaseJavaModule imple
         }
 
         try {
-            boolean hasPermission = ContextCompat.checkSelfPermission(getReactApplicationContext().getBaseContext(),
-                    android.Manifest.permission.CALL_PHONE) == PackageManager.PERMISSION_GRANTED;
-
-            if (hasPermission) {
-                call(Uri.encode(number), promise, currentActivity);
-            } else {
-                this.promise = promise;
-                this.number = Uri.encode(number);
-
-                ActivityCompat.requestPermissions(currentActivity,
-                        new String[]{android.Manifest.permission.CALL_PHONE},
-                        PERMISSIONS_REQUEST_ACCESS_CALL);
-            }
-        } catch(Exception e) {
-            promise.reject(new JSApplicationIllegalArgumentException("Could not open URL '" + number + "': " + e.getMessage()));
-        }
-    }
-
-    @SuppressLint("MissingPermission")
-    private void call(String number, Promise promise, Activity activity) {
-        try {
             String url = "tel:" + number;
             Intent intent = new Intent(Intent.ACTION_CALL, Uri.parse(url).normalizeScheme());
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             activity.startActivity(intent);
             promise.resolve("success");
-        } catch (Exception e) {
+        } catch(Exception e) {
             promise.reject(new JSApplicationIllegalArgumentException("Could not open URL '" + number + "': " + e.getMessage()));
         }
-    }
-
-    @Override
-    public boolean onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-        if (requestCode == PERMISSIONS_REQUEST_ACCESS_CALL) {// If request is cancelled, the result arrays are empty.
-            if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                call(number, promise, getCurrentActivity());
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/android/src/main/java/com/github/wumke/RNImmediatePhoneCall/RNImmediatePhoneCallModule.java
+++ b/android/src/main/java/com/github/wumke/RNImmediatePhoneCall/RNImmediatePhoneCallModule.java
@@ -1,5 +1,6 @@
 package com.github.wumke.RNImmediatePhoneCall;
 
+import android.app.Activity;
 import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -8,25 +9,21 @@ import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
 
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.modules.core.PermissionListener;
 
-public class RNImmediatePhoneCallModule extends ReactContextBaseJavaModule {
+public class RNImmediatePhoneCallModule extends ReactContextBaseJavaModule implements PermissionListener {
 
-    private static RNImmediatePhoneCallModule rnImmediatePhoneCallModule;
-
-    private ReactApplicationContext reactContext;
     private Promise promise;
-    private static String number = "";
+    private String number = "";
     private static final int PERMISSIONS_REQUEST_ACCESS_CALL = 101;
 
     public RNImmediatePhoneCallModule(ReactApplicationContext reactContext) {
         super(reactContext);
-        if (rnImmediatePhoneCallModule == null) {
-            rnImmediatePhoneCallModule = this;
-        }
-        rnImmediatePhoneCallModule.reactContext = reactContext;
     }
 
     @Override
@@ -38,58 +35,56 @@ public class RNImmediatePhoneCallModule extends ReactContextBaseJavaModule {
     public void immediatePhoneCall(String number, Promise promise) {
 
         if (number == null || number.isEmpty()) {
-            promise.reject(new JSApplicationIllegalArgumentException("Invalid number: " + url));
+            promise.reject(new JSApplicationIllegalArgumentException("Invalid number: " + number));
+            return;
+        }
+
+        Activity currentActivity = getCurrentActivity();
+        if (currentActivity == null) {
+            promise.reject(new JSApplicationIllegalArgumentException("Current Activity is null: " + number));
             return;
         }
 
         try {
-            Bool hasPermission = ContextCompat.checkSelfPermission(reactContext.getApplicationContext(),
-            android.Manifest.permission.CALL_PHONE) == PackageManager.PERMISSION_GRANTED
-
-            Activity currentActivity = getCurrentActivity();
-            if (currentActivity == null) {
-                currentActivity = getReactApplicationContext();
-            }
+            boolean hasPermission = ContextCompat.checkSelfPermission(getReactApplicationContext().getBaseContext(),
+                    android.Manifest.permission.CALL_PHONE) == PackageManager.PERMISSION_GRANTED;
 
             if (hasPermission) {
                 call(Uri.encode(number), promise, currentActivity);
             } else {
-                RNImmediatePhoneCallModule.promise = promise;
-                RNImmediatePhoneCallModule.number = Uri.encode(number);
+                this.promise = promise;
+                this.number = Uri.encode(number);
 
                 ActivityCompat.requestPermissions(currentActivity,
-                    new String[]{android.Manifest.permission.CALL_PHONE},
-                    PERMISSIONS_REQUEST_ACCESS_CALL);
+                        new String[]{android.Manifest.permission.CALL_PHONE},
+                        PERMISSIONS_REQUEST_ACCESS_CALL);
             }
         } catch(Exception e) {
-            promise.reject(new JSApplicationIllegalArgumentException("Could not open URL '" + url + "': " + e.getMessage()));
+            promise.reject(new JSApplicationIllegalArgumentException("Could not open URL '" + number + "': " + e.getMessage()));
         }
     }
-	
-	@SuppressLint("MissingPermission")
-    private static void call(String number, Promise promise, Activity activity) {
+
+    @SuppressLint("MissingPermission")
+    private void call(String number, Promise promise, Activity activity) {
         try {
             String url = "tel:" + number;
             Intent intent = new Intent(Intent.ACTION_CALL, Uri.parse(url).normalizeScheme());
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             activity.startActivity(intent);
+            promise.resolve("success");
         } catch (Exception e) {
-            promise.reject(new JSApplicationIllegalArgumentException("Could not open URL '" + url + "': " + e.getMessage()));
+            promise.reject(new JSApplicationIllegalArgumentException("Could not open URL '" + number + "': " + e.getMessage()));
         }
     }
 
-    public static void onRequestPermissionsResult(int requestCode, @NonNull String permissions[], @NonNull int[] grantResults) {
-        switch (requestCode) {
-            case PERMISSIONS_REQUEST_ACCESS_CALL: {
-                // If request is cancelled, the result arrays are empty.
-                if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                    Activity currentActivity = getCurrentActivity();
-                    if (currentActivity == null) {
-                        currentActivity = getReactApplicationContext();  
-                    }
-                    call(RNImmediatePhoneCallModule.number, RNImmediatePhoneCallModule.promise, currentActivity);
-                }
+    @Override
+    public boolean onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+        if (requestCode == PERMISSIONS_REQUEST_ACCESS_CALL) {// If request is cancelled, the result arrays are empty.
+            if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                call(number, promise, getCurrentActivity());
+                return true;
             }
         }
+        return false;
     }
 }

--- a/android/src/main/java/com/github/wumke/RNImmediatePhoneCall/RNImmediatePhoneCallModule.java
+++ b/android/src/main/java/com/github/wumke/RNImmediatePhoneCall/RNImmediatePhoneCallModule.java
@@ -45,10 +45,10 @@ public class RNImmediatePhoneCallModule extends ReactContextBaseJavaModule {
             String url = "tel:" + number;
             Intent intent = new Intent(Intent.ACTION_CALL, Uri.parse(url).normalizeScheme());
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            activity.startActivity(intent);
+            currentActivity.startActivity(intent);
             promise.resolve("success");
         } catch(Exception e) {
-            promise.reject(new JSApplicationIllegalArgumentException("Could not open URL '" + number + "': " + e.getMessage()));
+            promise.reject(new JSApplicationIllegalArgumentException("Could not open URL '" + url + "': " + e.getMessage()));
         }
     }
 }

--- a/android/src/main/java/com/github/wumke/RNImmediatePhoneCall/RNImmediatePhoneCallModule.java
+++ b/android/src/main/java/com/github/wumke/RNImmediatePhoneCall/RNImmediatePhoneCallModule.java
@@ -41,8 +41,8 @@ public class RNImmediatePhoneCallModule extends ReactContextBaseJavaModule {
             return;
         }
 
+        String url = "tel:" + number;
         try {
-            String url = "tel:" + number;
             Intent intent = new Intent(Intent.ACTION_CALL, Uri.parse(url).normalizeScheme());
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             currentActivity.startActivity(intent);

--- a/android/src/main/java/com/github/wumke/RNImmediatePhoneCall/RNImmediatePhoneCallPackage.java
+++ b/android/src/main/java/com/github/wumke/RNImmediatePhoneCall/RNImmediatePhoneCallPackage.java
@@ -35,10 +35,4 @@ public class RNImmediatePhoneCallPackage implements ReactPackage {
             ReactApplicationContext reactContext) {
         return Collections.emptyList();
     }
-	
-	public static void onRequestPermissionsResult(int requestCode, @NonNull String permissions[],
-                                                  @NonNull int[] grantResults) {
-        RNImmediatePhoneCallModule.onRequestPermissionsResult(requestCode, permissions, grantResults);
-    }
-
 }

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 import {NativeModules} from 'react-native';
 
 var RNImmediatePhoneCall = {
-  immediatePhoneCall: function(number) {
-        NativeModules.RNImmediatePhoneCall.immediatePhoneCall(number);
+  immediatePhoneCall: async function(number) {
+    return NativeModules.RNImmediatePhoneCall.immediatePhoneCall(number);
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -6,19 +6,24 @@ const defaultTitle = "Request Camera Permission";
 const defaultMessage = "Grant access to enable calling your phone";
 
 var RNImmediatePhoneCall = {
-  immediatePhoneCall: async function(number, title = defaultTitle, message = defaultMessage, buttonNegative = 'Cancel', buttonPositive = 'OK') {
+  immediatePhoneCall: async function(number, checkPermissions = true, title = defaultTitle, message = defaultMessage, buttonNegative = 'Cancel', buttonPositive = 'OK') {
     if (isAndroid) {
-      try {
-        let permission = await PermissionsAndroid.check(PermissionsAndroid.PERMISSIONS.CALL_PHONE);
-        if(!permission) {
-          let granted = await requestCallPermission(title, message, buttonNegative, buttonPositive);
-          if (granted) {
-            return NativeModules.RNImmediatePhoneCall.immediatePhoneCall(number);
+      if (checkPermissions) {
+        try {
+        
+          let permission = await PermissionsAndroid.check(PermissionsAndroid.PERMISSIONS.CALL_PHONE);
+          if(!permission) {
+            let granted = await requestCallPermission(title, message, buttonNegative, buttonPositive);
+            if (granted) {
+              return NativeModules.RNImmediatePhoneCall.immediatePhoneCall(number);
+            }
+            return Promise.reject("Permission not granted");
           }
-          return Promise.reject("Permission not granted");
+        } catch (e) {
+          return Promise.reject(e);
         }
-      } catch (e) {
-        return Promise.reject(e);
+      } else {
+        return NativeModules.RNImmediatePhoneCall.immediatePhoneCall(number);
       }
     }
     return NativeModules.RNImmediatePhoneCall.immediatePhoneCall(number);

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var RNImmediatePhoneCall = {
         if(!permission) {
           let granted = await requestCallPermission(title, message, buttonNegative, buttonPositive);
           if (granted) {
-            return NativeModules.RNImmediatePhoneCall.immediatePhoneCall("411");
+            return NativeModules.RNImmediatePhoneCall.immediatePhoneCall(number);
           }
           return Promise.reject("Permission not granted");
         }
@@ -21,7 +21,7 @@ var RNImmediatePhoneCall = {
         return Promise.reject(e);
       }
     }
-    return NativeModules.RNImmediatePhoneCall.immediatePhoneCall("411");
+    return NativeModules.RNImmediatePhoneCall.immediatePhoneCall(number);
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -1,9 +1,49 @@
-import {NativeModules} from 'react-native';
+import {NativeModules, Platform, PermissionsAndroid} from 'react-native';
+
+const isAndroid = Platform.OS === 'android';
+
+const defaultTitle = "Request Camera Permission";
+const defaultMessage = "Grant access to enable calling your phone";
 
 var RNImmediatePhoneCall = {
-  immediatePhoneCall: async function(number) {
-    return NativeModules.RNImmediatePhoneCall.immediatePhoneCall(number);
+  immediatePhoneCall: async function(number, title = defaultTitle, message = defaultMessage, buttonNegative = 'Cancel', buttonPositive = 'OK') {
+    if (isAndroid) {
+      try {
+        let permission = await PermissionsAndroid.check(PermissionsAndroid.PERMISSIONS.CALL_PHONE);
+        if(!permission) {
+          let granted = await requestCallPermission(title, message, buttonNegative, buttonPositive);
+          if (granted) {
+            return NativeModules.RNImmediatePhoneCall.immediatePhoneCall("411");
+          }
+          return Promise.reject("Permission not granted");
+        }
+      } catch (e) {
+        return Promise.reject(e);
+      }
+    }
+    return NativeModules.RNImmediatePhoneCall.immediatePhoneCall("411");
   }
 };
+
+async function requestCallPermission(title, message, buttonNegative, buttonPositive) {
+  try {
+    const granted = await PermissionsAndroid.request(
+      PermissionsAndroid.PERMISSIONS.CALL_PHONE,
+      {
+        title,
+        message,
+        buttonNegative,
+        buttonPositive
+      },
+    );
+    if (granted === PermissionsAndroid.RESULTS.GRANTED) {
+      return true;
+    } else {
+      return false;
+    }
+  } catch (err) {
+    return false;
+  }
+}
 
 export default RNImmediatePhoneCall;

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ import {NativeModules, Platform, PermissionsAndroid} from 'react-native';
 
 const isAndroid = Platform.OS === 'android';
 
-const defaultTitle = "Request Camera Permission";
+const defaultTitle = "Request Phone Permission";
 const defaultMessage = "Grant access to enable calling your phone";
 
 var RNImmediatePhoneCall = {

--- a/ios/RNImmediatePhoneCall/RNImmediatePhoneCall.m
+++ b/ios/RNImmediatePhoneCall/RNImmediatePhoneCall.m
@@ -1,6 +1,4 @@
-#import <UIKit/UIKit.h>
-#import "RCTBridgeModule.h"
-
+@import React;
 
 @interface RNImmediatePhoneCall : NSObject <RCTBridgeModule>
 @end
@@ -9,9 +7,27 @@
 
 RCT_EXPORT_MODULE();
 
-RCT_EXPORT_METHOD(immediatePhoneCall:(NSString *)number)
+RCT_EXPORT_METHOD(immediatePhoneCall:(NSString *)number resolve:(RCTPromiseResolveBlock _Nonnull)resolve rejecter:(RCTPromiseRejectBlock _Nonnull)reject)
 {
-    [[UIApplication sharedApplication] openURL:[NSURL URLWithString:[NSString stringWithFormat:@"tel:%@", number]]];
+  UIApplication *application = RCTSharedApplication();
+  if (application == nil) {
+    reject(@"OPEN_URL_NOT_AVAILABLE_IN_EXTENSION", @"does not support open url from app extension", nil);
+    return;
+  }
+  
+  NSURL *url = [NSURL URLWithString:[NSString stringWithFormat:@"tel:%@", number]];
+  if ([number isEqualToString:@""] || url == nil || [application canOpenURL:url] == false) {
+    reject(@"OPEN_URL_NOT_AVAILABLE", @"device does not support calling", nil);
+    return;
+  }
+  
+  [application openURL: url options: @{} completionHandler:^(BOOL success) {
+    if(success) {
+      resolve(@"Success");
+    } else {
+      reject(@"OPEN_URL_FAILED", @"failed to open url", nil);
+    }
+  }];
 };
 
 @end


### PR DESCRIPTION
In this pull request, both iOS and android were updated to be promised based, with iOS checking if it can open the URL and failing if it cannot before trying to open the URL which better follows apple API guidelines. Also updated to use the closure base method rather than the method that is flagged as being depreciated for opening the URL. Now we know via the promise in React-native if we were able to start the call. On android so it would also be promise based, and move the permission check to be in the JS, leveraging React-native permission methods for it.